### PR TITLE
HUD is now enabled by default

### DIFF
--- a/resources/leiningen/new/fulcro/shadow-cljs/package.json
+++ b/resources/leiningen/new/fulcro/shadow-cljs/package.json
@@ -2,9 +2,7 @@
   "name": "{{name}}",
   "version": "1.0.0",
   "description": "",
-  "main": "",
-  "repository": "",
-  "directories": {},
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "intl-messageformat": "^2.2.0",
@@ -13,7 +11,7 @@
     "karma-cljs-test": "^0.1.0",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
-    "shadow-cljs": "^2.0.129",
+    "shadow-cljs": "^2.0.150",
     "showdown": "^1.8.6"
   },
   "author": "",

--- a/resources/leiningen/new/fulcro/shadow-cljs/shadow-cljs.edn
+++ b/resources/leiningen/new/fulcro/shadow-cljs/shadow-cljs.edn
@@ -7,7 +7,7 @@
                      :modules    {:app {:entries [{{name}}.client]}}
 
                      :devtools   {:after-load {{name}}.client/start
-                                  :preloads [fulcro.inspect.preload {{name}}.development-preload shadow.cljs.devtools.client.hud]
+                                  :preloads [fulcro.inspect.preload {{name}}.development-preload]
                                   :http-root "resources/public"
                                   :http-port 8020}}
 
@@ -37,6 +37,6 @@
                      :modules          {:main
                                         {:entries [{{name}}.cards]}}
                      :devtools         {:after-load {{name}}.cards/refresh
-                                        :preloads [fulcro.inspect.preload {{name}}.development-preload shadow.cljs.devtools.client.hud]
+                                        :preloads [fulcro.inspect.preload {{name}}.development-preload]
                                         :http-root "resources/public"
                                         :http-port 8023}}}}


### PR DESCRIPTION
adding the `:preloads` is now redundant.

setting `private` in `package.json` also ensures you don't accidentally `npm publish` your project.