### PR TITLE
Update dependency on bidi to version 2.1.5

### DIFF
--- a/resources/leiningen/new/fulcro/project.clj
+++ b/resources/leiningen/new/fulcro/project.clj
@@ -16,7 +16,7 @@
                  [http-kit "2.3.0"]
                  [ring/ring-core "1.7.1"]
                  [bk/ring-gzip "0.3.0"]
-                 [bidi "2.1.4"]
+                 [bidi "2.1.5"]
 
                  ;; the following 3 are not used directly, but are pinned to ensure consistency.
                  ;; delete then if you upgrade anything and reanalyze deps


### PR DESCRIPTION
Version 2.1.5 of bidi has been released. Using this version will stop shadow-cljs UUID arity warnings.

See https://github.com/juxt/bidi/issues/189 and https://github.com/juxt/bidi/pull/190.