### PR TITLE
Migrate from org.clojure/tools.nrepl to nrepl

### DIFF
--- a/resources/leiningen/new/fulcro/deps.edn
+++ b/resources/leiningen/new/fulcro/deps.edn
@@ -29,4 +29,4 @@
                                      nubank/workspaces           {:mvn/version "1.0.3"},
                                      fulcrologic/fulcro-inspect  {:mvn/version "2.2.4"}
                                      org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}
-                                     org.clojure/tools.nrepl     {:mvn/version "0.2.13"}}}}}
+                                     nrepl                       {:mvn/version "0.6.0"}}}}}


### PR DESCRIPTION
The last release of `org.clojure/tools.nrepl` was in 2017 (https://github.com/clojure/tools.nrepl/releases). 

`nrepl` development continued at https://github.com/nrepl/nrepl. 

History: https://nrepl.org/nrepl/about/history.html.